### PR TITLE
Coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+plugins = Cython.Coverage

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 plugins = Cython.Coverage
+omit = stringsource

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cypcap.c
 /*.html
 /npcap-sdk/
 docs/_build/
+.coverage

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -20,6 +20,12 @@ Testing Setup
 
 Run pytest with `--interface=<iface>`, e.g. `--interface=dummy0`
 
+Coverage
+--------
+1. Uncomment ``define_macros=[("CYTHON_TRACE_NOGIL", 1)],`` & ``compiler_directives={'linetrace':
+   True},`` in ``setup.py``.
+2. Rebuild.
+
 VS Code
 -------
 ``.vscode/setting.json``:

--- a/cypcap.pyx
+++ b/cypcap.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3str, binding=True, linetrace=True
+# cython: language_level=3str, binding=True
 """
 This module is a Cython based binding for modern libpcap.
 """

--- a/cypcap.pyx
+++ b/cypcap.pyx
@@ -1,4 +1,4 @@
-# cython: language_level=3str, binding=True
+# cython: language_level=3str, binding=True, linetrace=True
 """
 This module is a Cython based binding for modern libpcap.
 """

--- a/setup.py
+++ b/setup.py
@@ -195,16 +195,19 @@ setup(
     ],
     keywords="libpcap pcap",
     zip_safe=False,
-    ext_modules=cythonize([
-        Extension(
-            "cypcap", ["cypcap.pyx"],
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            libraries=libraries,
-            extra_link_args=extra_link_args,
-            define_macros=[("CYTHON_TRACE_NOGIL", 1)],
-        ),
-    ]),
+    ext_modules=cythonize(
+        [
+            Extension(
+                "cypcap", ["cypcap.pyx"],
+                include_dirs=include_dirs,
+                library_dirs=library_dirs,
+                libraries=libraries,
+                extra_link_args=extra_link_args,
+                # define_macros=[("CYTHON_TRACE_NOGIL", 1)],
+            ),
+        ],
+        # compiler_directives={'linetrace': True},
+    ),
     cmdclass={"build_ext": build_ext},
     python_requires='>=3.6',
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -202,6 +202,7 @@ setup(
             library_dirs=library_dirs,
             libraries=libraries,
             extra_link_args=extra_link_args,
+            define_macros=[("CYTHON_TRACE_NOGIL", 1)],
         ),
     ]),
     cmdclass={"build_ext": build_ext},


### PR DESCRIPTION
- [ ] Need to find a way to conditionally enable `linetrace` and `CYTHON_TRACE_NOGIL`... The `--cython-directives` argument to `setup.py build_ext` seems broken https://github.com/cython/cython/issues/4441 &ndash; Workaround with commented out lines in `setup.py` for now (Possible after switching to `cythonize`)
- [ ] Getting a warning on stringsource on the generated coverage file. It's a bug https://github.com/cython/cython/pull/4440 &ndash; Workaround by adding `omit` to `.coveragerc`
- [ ] Add coverage to Github Actions (I wonder if there is a way to display coverage data nicely rather than just saving a report as an artifact. (Though codecov kinda sucked in most project I saw it on) &ndash; Deferred until I can figure out a proper way to enable coverage from CLI.
- [ ] Document in `TESTING.rst`