### PR TITLE
Replace makesockaddr_addr with C implementation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,11 @@ Added
 ^^^^^
 * ``Pkthdr`` can be created from Python and is mutable (Useful for ``bpf.offline_filter``).
 
+Changed
+^^^^^^^
+* Change ``findalldevs`` interface address parsing to use the same format as the ``socket``
+  module and add support for ``AF_PACKET`` ``sockaddr_ll`` used in Linux.
+
 v0.1.1 (2021-11-03)
 -------------------
 

--- a/LICENSE-PSF
+++ b/LICENSE-PSF
@@ -1,0 +1,47 @@
+Some code in this package is based on Python's code and marked as such.
+
+1. This LICENSE AGREEMENT is between the Python Software Foundation
+("PSF"), and the Individual or Organization ("Licensee") accessing and
+otherwise using this software ("Python") in source or binary form and
+its associated documentation.
+
+2. Subject to the terms and conditions of this License Agreement, PSF hereby
+grants Licensee a nonexclusive, royalty-free, world-wide license to reproduce,
+analyze, test, perform and/or display publicly, prepare derivative works,
+distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that PSF's License Agreement and PSF's notice of copyright,
+i.e., "Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021 Python Software Foundation;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. PSF is making Python available to Licensee on an "AS IS"
+basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between PSF and
+Licensee.  This License Agreement does not grant permission to use PSF
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include cypcap.c
 include *.pyx *.pxd *.pxi
+include LICENSE-PSF

--- a/csocket.pxd
+++ b/csocket.pxd
@@ -2,48 +2,14 @@ cdef extern from * nogil:
     """
     #ifdef _WIN32
     #include <WinSock2.h>
-    #include <WS2tcpip.h>
     #else
     #include <sys/socket.h>
-    #include <netinet/in.h>
-    #include <arpa/inet.h>
     #endif
     """
-    ctypedef int socklen_t
-
-    enum:
-        AF_INET
-        AF_INET6
-
-    enum:
-        INET_ADDRSTRLEN
-        INET6_ADDRSTRLEN
 
     struct sockaddr:
         unsigned short sa_family
         char sa_data[14]
-
-    struct in_addr:
-        unsigned long s_addr
-
-    struct sockaddr_in:
-        unsigned short sin_family
-        unsigned short sin_port
-        in_addr sin_addr
-        char sin_zero[8]
-
-    struct in6_addr:
-        unsigned char s6_addr[16]
-
-    struct sockaddr_in6:
-        unsigned short sin6_family
-        unsigned short sin6_port
-        unsigned long sin6_flowinfo
-        in6_addr sin6_addr
-        unsigned long sin6_scope_id
-
-    const char *inet_ntop(int af, const void* src,
-                          char* dst, socklen_t size)
 
     struct timeval:
         long tv_sec

--- a/setup.py
+++ b/setup.py
@@ -198,7 +198,7 @@ setup(
     ext_modules=cythonize(
         [
             Extension(
-                "cypcap", ["cypcap.pyx"],
+                "cypcap", ["cypcap.pyx", "sockaddr.c"],
                 include_dirs=include_dirs,
                 library_dirs=library_dirs,
                 libraries=libraries,

--- a/sockaddr.c
+++ b/sockaddr.c
@@ -1,0 +1,118 @@
+// This is based on Python's own socketmodule.c (See LICENSE-PSF)
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <pyconfig.h>
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#include <WS2tcpip.h>
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+#ifdef HAVE_NET_IF_H
+#include <net/if.h>
+#endif
+
+#ifdef HAVE_NETPACKET_PACKET_H
+#include <sys/ioctl.h>
+#include <netpacket/packet.h>
+#endif
+
+static PyObject *
+make_ipv4_addr(const struct sockaddr_in *addr)
+{
+    char buf[INET_ADDRSTRLEN];
+    if (inet_ntop(AF_INET, &addr->sin_addr, buf, sizeof(buf)) == NULL) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    return PyUnicode_FromString(buf);
+}
+
+static PyObject *
+make_ipv6_addr(const struct sockaddr_in6 *addr)
+{
+    char buf[INET6_ADDRSTRLEN];
+    if (inet_ntop(AF_INET6, &addr->sin6_addr, buf, sizeof(buf)) == NULL) {
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    return PyUnicode_FromString(buf);
+}
+
+PyObject *
+makesockaddr(struct sockaddr *addr)
+{
+    if (addr == NULL) {
+        /* No address */
+        Py_RETURN_NONE;
+    }
+
+    switch (addr->sa_family) {
+
+    case AF_INET:
+    {
+        const struct sockaddr_in *a = (const struct sockaddr_in *)addr;
+        PyObject *addrobj = make_ipv4_addr(a);
+        PyObject *ret = NULL;
+        if (addrobj) {
+            ret = Py_BuildValue("Oi", addrobj, ntohs(a->sin_port));
+            Py_DECREF(addrobj);
+        }
+        return ret;
+    }
+
+ case AF_INET6:
+    {
+        const struct sockaddr_in6 *a = (const struct sockaddr_in6 *)addr;
+        PyObject *addrobj = make_ipv6_addr(a);
+        PyObject *ret = NULL;
+        if (addrobj) {
+            ret = Py_BuildValue("OiII",
+                                addrobj,
+                                ntohs(a->sin6_port),
+                                ntohl(a->sin6_flowinfo),
+                                a->sin6_scope_id);
+            Py_DECREF(addrobj);
+        }
+        return ret;
+    }
+
+#if defined(HAVE_NETPACKET_PACKET_H) && defined(SIOCGIFNAME)
+    case AF_PACKET:
+    {
+        int sockfd = socket(AF_PACKET, SOCK_RAW, 0);
+        struct sockaddr_ll *a = (struct sockaddr_ll *)addr;
+        const char *ifname = "";
+        struct ifreq ifr;
+        /* need to look up interface name give index */
+        if (a->sll_ifindex) {
+            ifr.ifr_ifindex = a->sll_ifindex;
+            if (ioctl(sockfd, SIOCGIFNAME, &ifr) == 0)
+                ifname = ifr.ifr_name;
+        }
+        close(sockfd);
+        return Py_BuildValue("shbhy#",
+                             ifname,
+                             ntohs(a->sll_protocol),
+                             a->sll_pkttype,
+                             a->sll_hatype,
+                             a->sll_addr,
+                             (Py_ssize_t)a->sll_halen);
+    }
+#endif /* HAVE_NETPACKET_PACKET_H && SIOCGIFNAME */
+
+default:
+        /* If we don't know the address family, don't raise an
+           exception -- return it as an (int, bytes) tuple. */
+        return Py_BuildValue("iy#",
+                             addr->sa_family,
+                             addr->sa_data,
+                             sizeof(addr->sa_data));
+
+    }
+}


### PR DESCRIPTION
Based on the code in Python's socketmodule

This allows to add support to platform dependent sockaddr families as it is in C (Cython doesn't support `ifdef` for per platform stuff...)

Adding support for `AF_PACKET` `sockaddr_ll` used by Linux

Fixes #10