### PR TITLE
Reimplement BpfProgram.debug_dump in Python

### DIFF
--- a/cpcap.pxd
+++ b/cpcap.pxd
@@ -320,3 +320,5 @@ cdef extern from "<pcap/pcap.h>" nogil:
     const char *pcap_lib_version()
 
     void bpf_dump(const bpf_program *, int)
+
+    char *bpf_image(const bpf_insn *, int)

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -560,9 +560,21 @@ def test_offline_filter(echo_pkt):
     assert not bpf.offline_filter(pkthdr, data)
 
 
-def test_compile_dumps_disassembly():
+@pytest.mark.parametrize("type_, expected", [
+    (cypcap.BpfDumpType.DEFAULT, "2,40 0 0 12,6 0 0 65536"),
+    (cypcap.BpfDumpType.MULTILINE, "2\n40 0 0 12\n6 0 0 65536"),
+    (cypcap.BpfDumpType.C_ARRAY, "{ 0x28 0 0 0x0000000c },\n{ 0x6 0 0 0x00010000 },"),
+    (cypcap.BpfDumpType.DISASSEMBLY, "(000) ldh      [12]\n(001) ret      #65536"),
+])
+def test_dumps(type_, expected):
+    bpf = cypcap.BpfProgram([(40, 0, 0, 12), (6, 0, 0, 65536)])
+    assert bpf.dumps(type_) == expected
+
+
+@pytest.mark.parametrize("type_", list(cypcap.BpfDumpType))
+def test_compile_dumps(type_):
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    assert len(bpf.dumps(cypcap.BpfDumpType.DISASSEMBLY)) > 0
+    assert len(bpf.dumps(type_)) > 0
 
 
 def test_compile_dumps_loads():

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -578,26 +578,23 @@ def test_compile_dumps_loads():
     assert debug_dump1 == debug_dump2
 
 
-def test_compile_list_init(capfd):
+def test_compile_list_init():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    bpf.debug_dump()
-    debug_dump1 = capfd.readouterr()
+    debug_dump1 = bpf.debug_dump()
 
     dump = list(bpf)
     assert isinstance(dump, list)
     assert len(dump) == len(bpf)
 
     bpf2 = cypcap.BpfProgram(dump)
-    bpf2.debug_dump()
-    debug_dump2 = capfd.readouterr()
+    debug_dump2 = bpf2.debug_dump()
 
     assert debug_dump1 == debug_dump2
 
 
-def test_compile_iter(capfd):
+def test_compile_iter():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    bpf.debug_dump()
-    debug_dump = capfd.readouterr()
+    debug_dump = bpf.debug_dump()
 
     dump = [insn for insn in bpf]
     assert len(dump) == len(debug_dump.out.splitlines())

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -597,7 +597,7 @@ def test_compile_iter():
     debug_dump = bpf.debug_dump()
 
     dump = [insn for insn in bpf]
-    assert len(dump) == len(debug_dump.out.splitlines())
+    assert len(dump) == len(debug_dump.splitlines())
 
 
 def test_lib_version():

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -560,44 +560,44 @@ def test_offline_filter(echo_pkt):
     assert not bpf.offline_filter(pkthdr, data)
 
 
-def test_compile_debug_dump():
+def test_compile_dumps_disassembly():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    assert len(bpf.debug_dump()) > 0
+    assert len(bpf.dumps(cypcap.BpfDumpType.DISASSEMBLY)) > 0
 
 
 def test_compile_dumps_loads():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    debug_dump1 = bpf.debug_dump()
+    disasm_dump1 = bpf.dumps(cypcap.BpfDumpType.DISASSEMBLY)
 
     dump = bpf.dumps()
     assert isinstance(dump, str)
 
     bpf2 = cypcap.BpfProgram.loads(dump)
-    debug_dump2 = bpf2.debug_dump()
+    disasm_dump2 = bpf2.dumps(cypcap.BpfDumpType.DISASSEMBLY)
 
-    assert debug_dump1 == debug_dump2
+    assert disasm_dump1 == disasm_dump2
 
 
 def test_compile_list_init():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    debug_dump1 = bpf.debug_dump()
+    disasm_dump1 = bpf.dumps(cypcap.BpfDumpType.DISASSEMBLY)
 
     dump = list(bpf)
     assert isinstance(dump, list)
     assert len(dump) == len(bpf)
 
     bpf2 = cypcap.BpfProgram(dump)
-    debug_dump2 = bpf2.debug_dump()
+    disasm_dump2 = bpf2.dumps(cypcap.BpfDumpType.DISASSEMBLY)
 
-    assert debug_dump1 == debug_dump2
+    assert disasm_dump1 == disasm_dump2
 
 
 def test_compile_iter():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    debug_dump = bpf.debug_dump()
+    disasm_dump = bpf.dumps(cypcap.BpfDumpType.DISASSEMBLY)
 
     dump = [insn for insn in bpf]
-    assert len(dump) == len(debug_dump.splitlines())
+    assert len(dump) == len(disasm_dump.splitlines())
 
 
 def test_lib_version():

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -560,24 +560,20 @@ def test_offline_filter(echo_pkt):
     assert not bpf.offline_filter(pkthdr, data)
 
 
-def test_compile_debug_dump(capfd):
+def test_compile_debug_dump():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    bpf.debug_dump()
-    captured = capfd.readouterr()
-    assert len(captured.out) > 0
+    assert len(bpf.debug_dump()) > 0
 
 
-def test_compile_dumps_loads(capfd):
+def test_compile_dumps_loads():
     bpf = cypcap.compile(cypcap.DatalinkType.EN10MB, 65536, "tcp", True, cypcap.NETMASK_UNKNOWN)
-    bpf.debug_dump()
-    debug_dump1 = capfd.readouterr()
+    debug_dump1 = bpf.debug_dump()
 
     dump = bpf.dumps()
     assert isinstance(dump, str)
 
     bpf2 = cypcap.BpfProgram.loads(dump)
-    bpf2.debug_dump()
-    debug_dump2 = capfd.readouterr()
+    debug_dump2 = bpf2.debug_dump()
 
     assert debug_dump1 == debug_dump2
 


### PR DESCRIPTION
### TODO
- [x] Make *option* an enum and/or merge with `dumps`.
- [x] Tests

Fixes #23