### PR TITLE
Add a few platform specific Pcap functions

### DIFF
--- a/cpcap.pxd
+++ b/cpcap.pxd
@@ -64,6 +64,25 @@ cdef extern from "<pcap/pcap.h>" nogil:
             }
     }
     #endif
+
+    #ifndef __linux__
+    static int pcap_set_protocol_linux(pcap_t *, int)
+    {
+        return PCAP_ERROR;
+    }
+    #endif
+
+    #if defined(_WIN32) || defined(MSDOS)
+    static int pcap_get_selectable_fd(pcap_t *)
+    {
+        return -1;
+    }
+
+    static struct timeval *pcap_get_required_select_timeout(pcap_t *)
+    {
+        return NULL;
+    }
+    #endif
     """
 
     ctypedef unsigned int bpf_u_int32
@@ -229,6 +248,8 @@ cdef extern from "<pcap/pcap.h>" nogil:
         PCAP_TSTAMP_PRECISION_MICRO
         PCAP_TSTAMP_PRECISION_NANO
 
+    int pcap_set_protocol_linux(pcap_t *, int)  # Linux only
+
     pcap_t *pcap_open_live(const char *, int, bint, int, char *)
 
     pcap_t *pcap_open_dead(int, int)
@@ -320,3 +341,10 @@ cdef extern from "<pcap/pcap.h>" nogil:
     const char *pcap_lib_version()
 
     void bpf_dump(const bpf_program *, int)
+
+    # Windows only
+    void *pcap_getevent(pcap_t *p)
+
+    # UN*X only
+    int	pcap_get_selectable_fd(pcap_t *)
+    timeval *pcap_get_required_select_timeout(pcap_t *)

--- a/cpcap.pxd
+++ b/cpcap.pxd
@@ -65,6 +65,13 @@ cdef extern from "<pcap/pcap.h>" nogil:
     }
     #endif
 
+    #ifndef _WIN32
+    static void *pcap_getevent(pcap_t *p)
+    {
+        return 0;
+    }
+    #endif
+
     #ifndef __linux__
     static int pcap_set_protocol_linux(pcap_t *p, int protocol)
     {

--- a/cpcap.pxd
+++ b/cpcap.pxd
@@ -66,19 +66,19 @@ cdef extern from "<pcap/pcap.h>" nogil:
     #endif
 
     #ifndef __linux__
-    static int pcap_set_protocol_linux(pcap_t *, int)
+    static int pcap_set_protocol_linux(pcap_t *p, int protocol)
     {
         return PCAP_ERROR;
     }
     #endif
 
     #if defined(_WIN32) || defined(MSDOS)
-    static int pcap_get_selectable_fd(pcap_t *)
+    static int pcap_get_selectable_fd(pcap_t *p)
     {
         return -1;
     }
 
-    static struct timeval *pcap_get_required_select_timeout(pcap_t *)
+    static struct timeval *pcap_get_required_select_timeout(pcap_t *p)
     {
         return NULL;
     }

--- a/cypcap.pyx
+++ b/cypcap.pyx
@@ -1015,7 +1015,7 @@ cdef class Pcap:
         buffer_size: int=None,
         tstamp_type: TstampType=None,
         tstamp_precision: TstampPrecision=None,
-        protocol_linux: int,
+        protocol_linux: Optional[int]=None,
     ) -> None:
         """Set pre activation configuration from keyword arguments."""
 

--- a/cypcap.pyx
+++ b/cypcap.pyx
@@ -985,7 +985,7 @@ cdef class Pcap:
             """
             Get a file descriptor on which a ``select()`` can be done for a live capture.
 
-            Availability: UNIX (POSIX)
+            Availability: Unix (POSIX)
             """
             self._check_closed()
 
@@ -995,7 +995,7 @@ cdef class Pcap:
             """
             Get a timeout to be used when doing ``select()`` for a live capture.
 
-            Availability: UNIX (POSIX)
+            Availability: Unix (POSIX)
             """
             self._check_closed()
 

--- a/cypcap.pyx
+++ b/cypcap.pyx
@@ -3,6 +3,7 @@
 This module is a Cython based binding for modern libpcap.
 """
 
+import sys
 import os
 import socket  # To make sure WinSock2 is initialized
 import enum
@@ -13,6 +14,7 @@ from typing import Optional, Union, List, Tuple, Callable
 cimport cython
 from libc cimport stdio
 from libc.stdlib cimport malloc, free
+from libc.stdint cimport uintptr_t
 from cpython cimport PyObject, PyErr_SetFromErrno
 
 cimport cpcap
@@ -728,6 +730,19 @@ cdef class Pcap:
 
         return TstampPrecision(cpcap.pcap_get_tstamp_precision(self.pcap))
 
+    if sys.platform.startswith("linux"):
+        """
+        Set capture protocol for a not-yet-activated Pcap.
+
+        Availability: Linux
+        """
+        def set_protocol_linux(self, protocol: int) -> None:
+            self._check_closed()
+
+            err = cpcap.pcap_set_protocol_linux(self.pcap, protocol)
+            if err < 0:
+                raise Error(err, cpcap.pcap_statustostr(err).decode())
+
     def activate(self) -> None:
         """Activate a Pcap."""
         self._check_closed()
@@ -954,6 +969,43 @@ cdef class Pcap:
         if result < 0:
             raise Error(ErrorCode.ERROR, cpcap.pcap_geterr(self.pcap).decode())
 
+    if sys.platform == "win32":
+        def getevent(self) -> int:
+            """
+            Get an event ``HANDLE`` that can be used to unblock pcap.
+
+            Availability: Windows
+            """
+            self._check_closed()
+
+            return <uintptr_t>cpcap.pcap_getevent(self.pcap)
+
+    if os.name == "posix":
+        def get_selectable_fd(self) -> int:
+            """
+            Get a file descriptor on which a ``select()`` can be done for a live capture.
+
+            Availability: UNIX (POSIX)
+            """
+            self._check_closed()
+
+            return cpcap.pcap_get_selectable_fd(self.pcap)
+
+        def get_required_select_timeout(self) -> Optional[float]:
+            """
+            Get a timeout to be used when doing ``select()`` for a live capture.
+
+            Availability: UNIX (POSIX)
+            """
+            self._check_closed()
+
+            timeout = cpcap.pcap_get_required_select_timeout(self.pcap)
+
+            if timeout is not NULL:
+                return timeout.tv_sec + timeout.tv_usec / 1000000
+
+            return None
+
     def set_pre_config(self, *,
         snaplen: int=None,
         promisc: bool=None,
@@ -963,6 +1015,7 @@ cdef class Pcap:
         buffer_size: int=None,
         tstamp_type: TstampType=None,
         tstamp_precision: TstampPrecision=None,
+        protocol_linux: int,
     ) -> None:
         """Set pre activation configuration from keyword arguments."""
 
@@ -989,6 +1042,9 @@ cdef class Pcap:
 
         if tstamp_precision is not None:
             self.set_tstamp_precision(tstamp_precision)
+
+        if protocol_linux is not None:
+            self.set_protocol_linux(protocol_linux)
 
     def set_config(self, *,
         filter: Union[BpfProgram, str]=None,

--- a/tests/test_cypcap.py
+++ b/tests/test_cypcap.py
@@ -1,4 +1,4 @@
-import sys
+import os
 import socket
 from datetime import datetime
 import copy
@@ -544,6 +544,17 @@ def test_list_datalinks(pcap):
     datalinks = pcap.list_datalinks()
     assert len(datalinks) > 0
     assert cypcap.DatalinkType.EN10MB in datalinks
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Only supported on POSIX")
+def test_get_selectable_fd(pcap):
+    assert isinstance(pcap.get_selectable_fd(), int)
+
+
+@pytest.mark.skipif(os.name != "posix", reason="Only supported on POSIX")
+def test_get_required_select_timeout(pcap):
+    timeout = pcap.get_required_select_timeout()
+    assert timeout is None or isinstance(timeout, int)
 
 
 def test_nonexistent_interface():


### PR DESCRIPTION
### TODO
- [x] Tests
- [x] Since those are defined only on the platforms they are available on, need to do something about documentation which will pick them up depending on platform. &ndash; The functions will be defined but will raise due to work around.
- [x] Blocked on https://github.com/cython/cython/issues/4556 &ndash; Working around...

Fixes #14